### PR TITLE
Initial Bikeshed setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Build
+on:
+  pull_request: {}
+  push:
+    branches:
+    - main
+permissions:
+      contents: write
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: w3c/spec-prod@v2
+      with:
+        TOOLCHAIN: bikeshed
+        SOURCE: index.bs
+        DESTINATION: index.html
+        GH_PAGES_BRANCH: gh-pages
+        BUILD_FAIL_ON: warning

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+index.html

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,8 @@
+{
+  "src_file": "index.bs",
+  "type": "bikeshed",
+  "params": {
+    "force": 1
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [Local Peer-to-Peer](https://WICG.github.io/local-peer-to-peer/) is a Web platform API proposal for local communication between browsers without the aid of a server.
 
 ```js
-let session = await navigator.lp2p.findPeers();
-
+let peers = await navigator.lp2p.findPeers();
+let peer = peers[0];
+await peer.connect();
 await peer.send("Hello there!");
 ```
 
@@ -21,4 +22,4 @@ This specification is a work in progress.
 
 ## Feedback
 
-We welcome feedback [issue tracker](https://github.com/WICG/local-peer-to-peer/issues) of this GitHub repo. [Contributions](CONTRIBUTING.md) are welcome via pull requests too.
+We welcome feedback via the [issue tracker](https://github.com/WICG/local-peer-to-peer/issues) of this GitHub repo. [Contributions](CONTRIBUTING.md) are welcome via pull requests too.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 # Local Peer-to-Peer API
 
-For the latest proposals, see the [Local Peer-to-Peer API Explainer](EXPLAINER.md).
+[Local Peer-to-Peer](https://WICG.github.io/local-peer-to-peer/) is a Web platform API proposal for local communication between browsers without the aid of a server.
+
+```js
+let session = await navigator.lp2p.findPeers();
+
+await peer.send("Hello there!");
+```
+
+For a more in-dept overview of the proposal, please see the [Explainer](EXPLAINER.md).
+
+## Status
+
+This specification is a work in progress.
+
+## Links
+
+- [Explainer](EXPLAINER.md)
+- [Specification](https://WICG.github.io/local-peer-to-peer/)
 
 ## Feedback
 
-We welcome feedback via this GitHub repo issues. Contributions and suggestions to the [Explainer](EXPLAINER.md) are welcome via pull requests too.
+We welcome feedback [issue tracker](https://github.com/WICG/local-peer-to-peer/issues) of this GitHub repo. [Contributions](CONTRIBUTING.md) are welcome via pull requests too.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# Authors
-- Anssi Kostiainen (Intel)
-- Belem Zhang (Intel)
-- Wei Wang (Intel)
-
 # Local Peer-to-Peer API
 
 For the latest proposals, see the [Local Peer-to-Peer API Explainer](EXPLAINER.md).

--- a/index.bs
+++ b/index.bs
@@ -5,16 +5,16 @@ Level: 1
 Status: CG-DRAFT
 Group: WICG
 Repository: WICG/local-peer-to-peer
-URL: http://example.com/url-this-spec-will-live-at
+URL: https://WICG.github.io/local-peer-to-peer/
 Editor: Anssi Kostiainen, Intel https://intel.com, anssi.kostiainen@intel.com
 Editor: Belem Zhang, Intel https://intel.com, belem.zhang@intel.com
 Editor: Michiel De Backker, Twintag https://twintag.com, mail@backkem.me
 Editor: Wei Wang, Intel https://intel.com, wei4.wang@intel.com
 !Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/local-peer-to-peer>web-platform-tests local-peer-to-peer/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/local-peer-to-peer>ongoing work</a>)
-Abstract: A short description of your spec, one or two sentences.
+Abstract: Local Peer-to-Peer is a Web platform API proposal for local communication between browsers without the aid of a server.
 </pre>
 
 Introduction {#intro}
 =====================
 
-See https://github.com/tabatkins/bikeshed to get started.
+*This section is non-normative.*

--- a/index.bs
+++ b/index.bs
@@ -1,0 +1,17 @@
+<pre class='metadata'>
+Title: Local Peer-to-Peer API
+Shortname: local-peer-to-peer
+Level: 1
+Status: CG-DRAFT
+Group: WICG
+Repository: WICG/local-peer-to-peer
+URL: http://example.com/url-this-spec-will-live-at
+Editor: Belem Zhang, Intel https://intel.com, belem.zhang@intel.com
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/local-peer-to-peer>web-platform-tests local-peer-to-peer/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/local-peer-to-peer>ongoing work</a>)
+Abstract: A short description of your spec, one or two sentences.
+</pre>
+
+Introduction {#intro}
+=====================
+
+See https://github.com/tabatkins/bikeshed to get started.

--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,10 @@ Status: CG-DRAFT
 Group: WICG
 Repository: WICG/local-peer-to-peer
 URL: http://example.com/url-this-spec-will-live-at
+Editor: Anssi Kostiainen, Intel https://intel.com, anssi.kostiainen@intel.com
 Editor: Belem Zhang, Intel https://intel.com, belem.zhang@intel.com
+Editor: Michiel De Backker, Twintag https://twintag.com, mail@backkem.me
+Editor: Wei Wang, Intel https://intel.com, wei4.wang@intel.com
 !Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/local-peer-to-peer>web-platform-tests local-peer-to-peer/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/local-peer-to-peer>ongoing work</a>)
 Abstract: A short description of your spec, one or two sentences.
 </pre>


### PR DESCRIPTION
This PR contains the initial Bikeshed build setup. Once the build is complete, Github Pages can be enabled on the repo.