### PR TITLE
Adhere closer to MessageEvent

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -76,7 +76,7 @@ conn.ondatachannel = (e) => {
 const channel = conn.createDataChannel("My Channel");
 
 channel.onmessage = (e) => {
-  console.log(`Receiver: Received message: ${e.message}`);
+  console.log(`Receiver: Received message: ${e.data}`);
 };
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -632,7 +632,7 @@ receiver.onconnection = e => {
         const channel = e.channel;
 
         channel.onmessage = e => {
-            const message = e.message;
+            const message = e.data;
             console.log(\`Receiver: Received message: ${message}\`);
         };
 


### PR DESCRIPTION
Changed `.message` into `.data` to adhere to [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/backkem/local-peer-to-peer/pull/27.html" title="Last updated on Dec 22, 2023, 7:49 AM UTC (b36f1e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/local-peer-to-peer/27/71d142a...backkem:b36f1e2.html" title="Last updated on Dec 22, 2023, 7:49 AM UTC (b36f1e2)">Diff</a>